### PR TITLE
Bugifix: Webpack server realod not working

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -75,6 +75,8 @@ module.exports = {
 
     devServer: {
         port: '3000',
+        historyApiFallback: true,
+        hot: true,
     },
 
     devtool: 'inline-source-map'


### PR DESCRIPTION
The current frontend throws a _not-allowed_ error. This is an issue of the webpack-dev-server. This PR resolves this issue by allowing reloading the api-path.  